### PR TITLE
Form - New Option - Only Page Owner Can add responses (removed 1 response restriction. now page owner can add multiple responses)

### DIFF
--- a/packages/web/src/components/form2/Form.tsx
+++ b/packages/web/src/components/form2/Form.tsx
@@ -95,7 +95,11 @@ export default function Form({ _id, drawerMode = false, onSlugChange }: IProps):
   if (!state?.settings?.ViewAuthRequired && !admin) {
     return (
       <div style={{ width: '100%' }}>
-        <FormView form={state} />
+        {state?.settings?.onlyOwnerCanSubmit ? (
+          <ResponseList form={state} />
+        ) : (
+          <FormView form={state} />
+        )}
       </div>
     );
   } else {

--- a/packages/web/src/components/form2/FormSetting.tsx
+++ b/packages/web/src/components/form2/FormSetting.tsx
@@ -107,7 +107,7 @@ export default function FormSetting({ settings, onChange }: IProps): any {
               color="primary"
             />
           }
-          label="Only page owner can submit 1 response other users will see the that 1 response"
+          label="Only page owner can submit response other users will see the responses"
         />
       </InputGroup>
       <InputGroup>


### PR DESCRIPTION
This is the requirement:
[https://www.boossti.com/mern-requirements-implementation/form-settings-only-page-owner-can-submit-responses-and-others-can-see-the-results](https://www.boossti.com/mern-requirements-implementation/form-settings-only-page-owner-can-submit-responses-and-others-can-see-the-results)
