### PR TITLE
expose all page variables bug fix, show workflows below response

### DIFF
--- a/packages/web/src/components/form2/ActionForm.tsx
+++ b/packages/web/src/components/form2/ActionForm.tsx
@@ -290,7 +290,7 @@ export default function ActionForm({ onCancel, fields, emailFields, onSave, acti
                     'variables',
                     formik.values.variables.map((sV, sI) => {
                       if (sI === i) {
-                        let payload = { ...variable, field: target.value };
+                        let payload = { ...variable, field: target.value, formId: null };
                         const field = fields?.filter((f) => f._id === target.value && f?.formId)[0];
                         if (field) {
                           payload = { ...payload, formId: field.formId };

--- a/packages/web/src/components/form2/CustomFormSettings.tsx
+++ b/packages/web/src/components/form2/CustomFormSettings.tsx
@@ -39,6 +39,7 @@ export default function CustomFormSettings({
 
   const getFormFields = async () => {
     const formFields = fields?.filter((f) => f?.fieldType === 'form' && f?.form?._id !== formId);
+    let newPageFields = [];
     for (const field of formFields) {
       const form = await getForm(field?.form?._id);
       if (form) {
@@ -47,9 +48,10 @@ export default function CustomFormSettings({
           label: `${field?.label}-${f?.label}`,
           formId: form?._id,
         }));
-        setPageFields([...pageFields, ...pageField]);
+        newPageFields = [...newPageFields, ...pageField];
       }
     }
+    setPageFields(newPageFields);
   };
 
   return (

--- a/packages/web/src/components/form2/FormView.tsx
+++ b/packages/web/src/components/form2/FormView.tsx
@@ -85,20 +85,23 @@ export default function FormViewWrapper({
     };
     const response = await handleCreateUpdateResponse(payload, form?.fields);
     if (response) {
-      const messages = await Promise.all(
-        form?.settings?.actions
-          ?.filter((a) => a?.actionType === 'showMessage' && a?.active)
-          ?.map(async (a) => {
-            const message = await replaceVariables(
-              a?.body,
-              a?.variables,
-              form?.fields,
-              response?.values,
-              parentId,
-            );
-            return message;
-          }),
-      );
+      let messages = [];
+      // if (form?.settings?.actions?.length > 0) {
+      //   messages = await Promise.all(
+      //     form?.settings?.actions
+      //       ?.filter((a) => a?.actionType === 'showMessage' && a?.active)
+      //       ?.map(async (a) => {
+      //         const message = await replaceVariables(
+      //           a?.body,
+      //           a?.variables,
+      //           form?.fields,
+      //           response?.values,
+      //           parentId,
+      //         );
+      //         return message;
+      //       }),
+      //   );
+      // }
       setState({ ...state, submitted: true, formModal: false, messages, response });
       if (createCallback) {
         createCallback(response);
@@ -596,10 +599,8 @@ const replaceVariables = async (oldBody, oldVariables, fields, values, pageId) =
     const variable = { ...oneVariable, value: '' };
     let field = null;
     let value = null;
-
     field = fields.find((f) => f._id === variable?.field);
     value = values?.find((v) => v.field === variable?.field);
-
     if (variable.formId) {
       const form = forms?.find((f) => f._id === variable.formId);
       if (form) {
@@ -607,7 +608,6 @@ const replaceVariables = async (oldBody, oldVariables, fields, values, pageId) =
         value = form?.response?.values?.find((v) => v.field === variable?.field);
       }
     }
-
     if (field && value) {
       variable.value = getValue(field, value);
     }

--- a/packages/web/src/components/response/Response.tsx
+++ b/packages/web/src/components/response/Response.tsx
@@ -1,3 +1,4 @@
+import { useSelector } from 'react-redux';
 import { useState } from 'react';
 import { useGetForm } from '@frontend/shared/hooks/form';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -26,6 +27,7 @@ import FormFieldsValue from '../form2/FormFieldsValue';
 import { onAlert } from '../../utils/alert';
 import CRUDMenu from '../common/CRUDMenu';
 import BackdropComponent from '../common/Backdrop';
+import EditMode from '../common/EditMode';
 
 interface IProps {
   responseId: string;
@@ -115,10 +117,12 @@ export function ResponseChild3({
   const [state, setState] = useState({ showMenu: null, edit: false });
   const { handleDelete, deleteLoading } = useDeleteResponse({ onAlert });
   const authorized = useAuthorization([response?.createdBy?._id, form?.createdBy?._id], true);
+  const authorized2 = useAuthorization([form?.createdBy?._id], true);
   const { section, onSectionChange, handleUpdateSection } = useUpdateSection({
     onAlert,
     _id: JSON.parse(response?.options)?.customSectionId || form._id,
   });
+  const { editMode } = useSelector(({ setting }: any) => setting);
 
   return (
     <>
@@ -133,7 +137,12 @@ export function ResponseChild3({
             </Breadcrumbs>
           )}
           <div className="d-flex align-items-center">
-            {!hideNavigation && <QRButton />}
+            {!hideNavigation && (
+              <>
+                <EditMode />
+                <QRButton />
+              </>
+            )}
             {authorized && (
               <>
                 <Tooltip title="Edit Response">
@@ -179,7 +188,7 @@ export function ResponseChild3({
                 onSectionChange={(sec) => {}}
               />
               <Paper variant="outlined">
-                <List dense component="nav" aria-label="main mailbox folders">
+                <List dense component="nav">
                   <ListItem button>
                     <ListItemText primary="Form Fields" />
                   </ListItem>
@@ -201,13 +210,14 @@ export function ResponseChild3({
               section?.options?.belowResponse ? 'flex-column-reverse' : 'flex-column'
             }`}
           >
-            {!(hideAuthor || hideNavigation || hideBreadcrumbs) && (
+            {section?.fields?.length > 0 && (
               <FormFieldsValue
-                authorized={false}
+                authorized={authorized2}
+                disableGrid={!editMode}
                 fields={section?.fields}
                 values={section?.values}
-                handleValueChange={handleUpdateSection}
                 layouts={section?.options?.layouts || {}}
+                handleValueChange={handleUpdateSection}
                 onLayoutChange={(layouts) =>
                   onSectionChange({
                     options: { ...section?.options, layouts },


### PR DESCRIPTION
Now it shows all page fields in drop down

<img width="1440" alt="Screenshot 2022-03-04 at 5 28 11 AM" src="https://user-images.githubusercontent.com/50275510/156673733-54ba0ffb-8b2f-497c-a24a-c83748b3ea39.png">



Show the workflows response sections

<img width="1440" alt="Screenshot 2022-03-04 at 5 34 48 AM" src="https://user-images.githubusercontent.com/50275510/156673883-bdf305ea-82a7-40a5-b24c-8a28cb6be095.png">

if the response sections doesn't show then delete the response and again submit it from the page











