### PR TITLE
edit response in overlay, forms settings-only page owner can fill forms on the page- who can see the responses.

### DIFF
--- a/packages/shared/graphql/query/response.ts
+++ b/packages/shared/graphql/query/response.ts
@@ -149,6 +149,7 @@ export const GET_RESPONSES = gql`
           name
         }
         createdAt
+        options
       }
     }
   }

--- a/packages/web/src/components/common/DeleteButton.tsx
+++ b/packages/web/src/components/common/DeleteButton.tsx
@@ -1,0 +1,29 @@
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+export default function DeleteButton({
+  onClick,
+  tooltip = 'Delete',
+  edge = false,
+}: {
+  onClick: () => void;
+  tooltip?: string;
+  edge?: any;
+}) {
+  return (
+    <Tooltip title={tooltip}>
+      <IconButton
+        onClick={() => {
+          const anwser = confirm('Are you sure you want to delete this response');
+          if (anwser) {
+            onClick();
+          }
+        }}
+        edge={edge}
+      >
+        <DeleteIcon />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/packages/web/src/components/common/ImagePicker.tsx
+++ b/packages/web/src/components/common/ImagePicker.tsx
@@ -21,7 +21,7 @@ export default function ImagePicker({
 }: IProps): any {
   const [id, setId] = useState('');
   const ref: any = useRef();
-  const newArray = [...state.tempMedia];
+  const newArray = state.tempMedia?.length > 0 ? [...state.tempMedia] : [];
 
   useEffect(() => {
     setId(generateObjectId());

--- a/packages/web/src/components/form2/Field.tsx
+++ b/packages/web/src/components/form2/Field.tsx
@@ -160,19 +160,6 @@ export default function FieldValueForm2({
         </div>
       );
     }
-    // case 'media': {
-    //   return (
-    //     <div>
-    //       <FormLabel component="legend">Select {label}</FormLabel>
-    //       <ImagePicker state={mediaState} setState={setMediaState} />
-    //       {validateValue(validate, value, options, fieldType).error && (
-    //         <FormHelperText className="text-danger">
-    //           {validateValue(validate, value, options, fieldType).errorMessage}
-    //         </FormHelperText>
-    //       )}
-    //     </div>
-    //   );
-    // }
     case 'select': {
       return (
         <>
@@ -241,7 +228,7 @@ export default function FieldValueForm2({
             country="us"
             preferredCountries={['us']}
             enableSearch
-            value={value ? value.valueNumber : ''}
+            value={value?.valueNumber?.toString() || ''}
             onChange={(phone) => onChange({ field: _id, valueNumber: phone })}
             inputStyle={
               validateValue(validate, value, options, fieldType).error ? { borderColor: 'red' } : {}

--- a/packages/web/src/components/form2/FormFieldsValue.tsx
+++ b/packages/web/src/components/form2/FormFieldsValue.tsx
@@ -15,7 +15,7 @@ import CommentLikeShare from '../common/commentLikeShare/CommentLikeShare';
 import { DisplayForm } from './FormSection';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
-import { getForm } from '@frontend/shared/hooks/form';
+// import { getForm } from '@frontend/shared/hooks/form';
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
@@ -49,41 +49,41 @@ export default function FormFieldsValue({
   onLayoutChange,
 }: IProps) {
   const [state, setState] = useState(initialState);
-  const [height, setheight] = useState([]);
+  // const [height, setheight] = useState([]);
   // const [layout, setLayout] = useState({});
 
   const setInitialState = () => setState(initialState);
 
-  const countFormHeight = (forms) => {
-    let formHeights = [];
-    forms.map(async (form) => {
-      let height = 128; //default height for each form
-      let pageForm = await getForm(form.form._id);
-      pageForm.fields.map((field) => {
-        console.log(field);
-        if (
-          field.fieldType == 'text' ||
-          field.fieldType == 'number' ||
-          field.fieldType == 'password' ||
-          field.fieldType == 'checkbox' ||
-          field.fieldType == 'select' ||
-          field.fieldType == 'email' ||
-          field.fieldType == 'dateTime' ||
-          field.fieldType == 'phoneNumber'
-        ) {
-          height = height + 85.25;
-        }
-        if (field.fieldType == 'textarea' || field.fieldType == 'richTextarea') {
-          height = height + 156.5;
-        }
-      });
-      formHeights.push(height);
-    });
-    setTimeout(() => {
-      console.log(formHeights);
-    }, 3000);
-    return formHeights;
-  };
+  // const countFormHeight = (forms) => {
+  //   let formHeights = [];
+  //   forms.map(async (form) => {
+  //     let height = 128; //default height for each form
+  //     let pageForm = await getForm(form.form._id);
+  //     pageForm.fields.map((field) => {
+  //       console.log(field);
+  //       if (
+  //         field.fieldType == 'text' ||
+  //         field.fieldType == 'number' ||
+  //         field.fieldType == 'password' ||
+  //         field.fieldType == 'checkbox' ||
+  //         field.fieldType == 'select' ||
+  //         field.fieldType == 'email' ||
+  //         field.fieldType == 'dateTime' ||
+  //         field.fieldType == 'phoneNumber'
+  //       ) {
+  //         height = height + 85.25;
+  //       }
+  //       if (field.fieldType == 'textarea' || field.fieldType == 'richTextarea') {
+  //         height = height + 156.5;
+  //       }
+  //     });
+  //     formHeights.push(height);
+  //   });
+  //   setTimeout(() => {
+  //     console.log(formHeights);
+  //   }, 3000);
+  //   return formHeights;
+  // };
 
   const handleSubmit = async (tempValues: any) => {
     let newValues = values ? [...values] : [];
@@ -104,11 +104,11 @@ export default function FormFieldsValue({
     await handleValueChange({ values: newValues }, setInitialState);
   };
 
-  useEffect(() => {
-    setTimeout(() => {
-      setheight(countFormHeight(fields));
-    }, 2000);
-  }, []);
+  // useEffect(() => {
+  //   setTimeout(() => {
+  //     setheight(countFormHeight(fields));
+  //   }, 2000);
+  // }, []);
 
   return (
     <div className="p-2">

--- a/packages/web/src/components/form2/FormSection.tsx
+++ b/packages/web/src/components/form2/FormSection.tsx
@@ -1,14 +1,13 @@
 import { useState } from 'react';
 import { useGetResponses } from '@frontend/shared/hooks/response';
 import Button from '@material-ui/core/Button';
-import AddIcon from '@material-ui/icons/Add';
-import { IconButton } from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+// import AddIcon from '@material-ui/icons/Add';
+// import { IconButton } from '@material-ui/core';
+// import CloseIcon from '@material-ui/icons/Close';
+// import Response from '../response/Response';
 import FieldViewWrapper from './FieldViewWrapper';
-import Response from '../response/Response';
 import ErrorLoading from '../common/ErrorLoading';
 import Overlay from '../common/Overlay';
-import { ResponseListWrapper } from '../response/ResponseList';
 
 export const DisplayForm = ({
   formId,
@@ -34,84 +33,66 @@ export const DisplayForm = ({
 
   return (
     <>
-      {!(customSettings?.widgetType === 'onlyPageOwner') ? (
-        <>
-          <div className="text-center">
-            <Button variant="outlined" onClick={() => setState({ ...state, drawer: true })}>
-              {`${data?.getResponses?.count} Responses`}
-            </Button>
-          </div>
-          {state.drawer && (
-            <Overlay
-              minWidth="85vw"
-              title="Responses"
-              open={state.drawer}
-              onClose={() => setState({ ...state, drawer: false })}
-            >
-              <ResponseListWrapper formId={formId} parentId={parentId} />
-            </Overlay>
-          )}
-          <FieldViewWrapper _id={formId} parentId={parentId} customSettings={customSettings} />
-        </>
-      ) : authorized && !(data?.getResponses && data?.getResponses?.count > 0) ? (
-        <FieldViewWrapper _id={formId} parentId={parentId} customSettings={customSettings} />
-      ) : (
-        (authorized || customSettings?.showResponses) && (
-          <>
-            {customSettings?.multipleResponses && (
-              <>
-                {state.showForm ? (
-                  <>
-                    <div className="text-right">
-                      <IconButton
-                        size="small"
-                        onClick={() => setState({ ...state, showForm: false })}
-                      >
-                        <CloseIcon />
-                      </IconButton>
-                    </div>
-                    <FieldViewWrapper
-                      _id={formId}
-                      parentId={parentId}
-                      customSettings={customSettings}
-                      createCallback={(r) => {
-                        handleRefetch();
-                        setState({ ...state, showForm: false });
-                      }}
-                    />
-                  </>
-                ) : (
-                  authorized && (
-                    <Button
-                      variant="contained"
-                      color="primary"
-                      size="small"
-                      startIcon={<AddIcon />}
-                      onClick={() => setState({ ...state, showForm: true })}
-                    >
-                      Add new
-                    </Button>
-                  )
-                )}
-              </>
-            )}
-            {(customSettings?.multipleResponses
-              ? data?.getResponses?.data
-              : [data?.getResponses?.data?.[0]]
-            )
-              ?.slice(0)
-              .reverse()
-              ?.map((response) => (
-                <Response
-                  key={response?._id}
-                  hideNavigation
-                  hideAuthor
-                  responseId={response?._id}
-                />
-              ))}
-          </>
-        )
-      )}
+      <FieldViewWrapper _id={formId} parentId={parentId} customSettings={customSettings} />
+      {/* //  : authorized && !(data?.getResponses && data?.getResponses?.count > 0) ? (
+      //   <FieldViewWrapper _id={formId} parentId={parentId} customSettings={customSettings} />
+      // ) : (
+      //   (authorized || customSettings?.showResponses) && (
+      //     <>
+      //       {customSettings?.multipleResponses && (
+      //         <>
+      //           {state.showForm ? (
+      //             <>
+      //               <div className="text-right">
+      //                 <IconButton
+      //                   size="small"
+      //                   onClick={() => setState({ ...state, showForm: false })}
+      //                 >
+      //                   <CloseIcon />
+      //                 </IconButton>
+      //               </div>
+      //               <FieldViewWrapper
+      //                 _id={formId}
+      //                 parentId={parentId}
+      //                 customSettings={customSettings}
+      //                 createCallback={(r) => {
+      //                   handleRefetch();
+      //                   setState({ ...state, showForm: false });
+      //                 }}
+      //               />
+      //             </>
+      //           ) : (
+      //             authorized && (
+      //               <Button
+      //                 variant="contained"
+      //                 color="primary"
+      //                 size="small"
+      //                 startIcon={<AddIcon />}
+      //                 onClick={() => setState({ ...state, showForm: true })}
+      //               >
+      //                 Add new
+      //               </Button>
+      //             )
+      //           )}
+      //         </>
+      //       )}
+      //       {(customSettings?.multipleResponses
+      //         ? data?.getResponses?.data
+      //         : [data?.getResponses?.data?.[0]]
+      //       )
+      //         ?.slice(0)
+      //         .reverse()
+      //         ?.map((response) => (
+      //           <Response
+      //             key={response?._id}
+      //             hideNavigation
+      //             hideAuthor
+      //             responseId={response?._id}
+      //           />
+      //         ))}
+      //     </>
+      //   )
+      // )} */}
     </>
   );
 };

--- a/packages/web/src/components/form2/FormSetting.tsx
+++ b/packages/web/src/components/form2/FormSetting.tsx
@@ -16,29 +16,41 @@ interface IProps {
 export default function FormSetting({ formId, settings, onChange, isSection }: IProps): any {
   return (
     <Paper variant="outlined" className="p-2">
-      <TextField
-        fullWidth
-        size="small"
-        variant="outlined"
-        select
-        id="demo-simple-select"
-        value={settings?.widgetType ?? 'fullForm'}
-        label="Widget type"
-        onChange={({ target }) => onChange({ widgetType: target.value })}
-      >
-        <MenuItem value="fullForm">Full Form</MenuItem>
-        <MenuItem value="leaderboard">Leaderboad</MenuItem>
-        <MenuItem value="oneField">One field at a time</MenuItem>
-        <MenuItem value="button">Button</MenuItem>
-        <MenuItem value="displayResponses">Display Responses</MenuItem>
-        <MenuItem value="displayVertical">
-          Display result on one page in vertical one below the other
-        </MenuItem>
-        <MenuItem value="selectItem">Select Item</MenuItem>
-        {isSection && (
-          <MenuItem value="onlyPageOwner">Only page owner can submit response</MenuItem>
-        )}
-      </TextField>
+      <InputGroup>
+        <TextField
+          fullWidth
+          size="small"
+          variant="outlined"
+          select
+          id="demo-simple-select"
+          value={settings?.widgetType ?? 'fullForm'}
+          label="Widget type"
+          onChange={({ target }) => onChange({ widgetType: target.value })}
+        >
+          <MenuItem value="fullForm">Full Form</MenuItem>
+          <MenuItem value="leaderboard">Leaderboad</MenuItem>
+          <MenuItem value="oneField">One field at a time</MenuItem>
+          <MenuItem value="button">Button</MenuItem>
+          <MenuItem value="displayResponses">Display Responses</MenuItem>
+          <MenuItem value="selectItem">Select Item</MenuItem>
+        </TextField>
+      </InputGroup>
+      {settings?.widgetType === 'displayResponses' && (
+        <InputGroup>
+          <TextField
+            fullWidth
+            size="small"
+            variant="outlined"
+            select
+            value={settings?.responsesView ?? 'table'}
+            label="Responses view"
+            onChange={({ target }) => onChange({ responsesView: target.value })}
+          >
+            <MenuItem value="table">Table</MenuItem>
+            <MenuItem value="vertical">Vertical</MenuItem>
+          </TextField>
+        </InputGroup>
+      )}
       {settings?.widgetType === 'leaderboard' && (
         <InputGroup>
           <h3>Leader Board</h3>
@@ -92,35 +104,35 @@ export default function FormSetting({ formId, settings, onChange, isSection }: I
           />
         </div>
       )}
-      {!(settings?.widgetType === 'onlyPageOwner') && (
-        <>
-          <InputGroup>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={!settings?.authRequired}
-                  onChange={({ target }) => onChange({ authRequired: !target.checked })}
-                  name="authRequired"
-                  color="primary"
-                />
-              }
-              label="Authentication required to submit form"
-            />
-          </InputGroup>
-          <InputGroup>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={settings?.ViewAuthRequired}
-                  onChange={({ target }) => onChange({ ViewAuthRequired: target.checked })}
-                  name="authRequired"
-                  color="primary"
-                />
-              }
-              label="Authentication required to view form"
-            />
-          </InputGroup>
-        </>
+      <InputGroup>
+        <TextField
+          fullWidth
+          size="small"
+          variant="outlined"
+          select
+          value={settings?.whoCanSubmit ?? 'authUser'}
+          label="Who can submit the response"
+          onChange={({ target }) => onChange({ whoCanSubmit: target.value })}
+        >
+          <MenuItem value="all">{'Both authenticated & unauthenticated users'}</MenuItem>
+          <MenuItem value="authUser">Only Authenticated users</MenuItem>
+          {isSection && <MenuItem value="onlyPageOwner">Only page owner</MenuItem>}
+        </TextField>
+      </InputGroup>
+      {!(settings?.whoCanSubmit === 'all') && (
+        <InputGroup>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={settings?.viewAuthRequired}
+                onChange={({ target }) => onChange({ viewAuthRequired: target.checked })}
+                name="authRequired"
+                color="primary"
+              />
+            }
+            label="Authentication required to view form"
+          />
+        </InputGroup>
       )}
       <InputGroup>
         <FormControlLabel

--- a/packages/web/src/components/response/Response.tsx
+++ b/packages/web/src/components/response/Response.tsx
@@ -124,10 +124,12 @@ export function ResponseChild3({
   });
   const { editMode } = useSelector(({ setting }: any) => setting);
 
+  const hideLeftNavigation = !(hideAuthor || hideNavigation || hideBreadcrumbs);
+
   return (
     <>
       <BackdropComponent open={deleteLoading} />
-      {!hideBreadcrumbs && (
+      {!hideBreadcrumbs ? (
         <div className="d-flex justify-content-between align-items-center">
           {!hideNavigation && (
             <Breadcrumbs>
@@ -144,38 +146,50 @@ export function ResponseChild3({
               </>
             )}
             {authorized && (
-              <>
-                <Tooltip title="Edit Response">
-                  <IconButton onClick={(e) => setState({ ...state, showMenu: e.currentTarget })}>
-                    <EditIcon />
-                  </IconButton>
-                </Tooltip>
-                <CRUDMenu
-                  show={state.showMenu}
-                  onEdit={() => setState({ ...state, showMenu: null, edit: true })}
-                  onDelete={() => {
-                    setState({ ...state, showMenu: null });
-                    handleDelete(response?._id, form?._id);
-                  }}
-                  onClose={() => setState({ ...state, showMenu: null })}
-                />
-                {state.edit && (
-                  <EditResponseDrawer
-                    form={form}
-                    response={response}
-                    open={state.edit}
-                    onClose={() => {
-                      setState({ ...state, edit: false });
-                    }}
-                  />
-                )}
-              </>
+              <Tooltip title="Edit Response">
+                <IconButton onClick={(e) => setState({ ...state, showMenu: e.currentTarget })}>
+                  <EditIcon />
+                </IconButton>
+              </Tooltip>
             )}
           </div>
         </div>
+      ) : (
+        authorized && (
+          <Tooltip title="Edit Response">
+            <IconButton onClick={(e) => setState({ ...state, showMenu: e.currentTarget })}>
+              <EditIcon />
+            </IconButton>
+          </Tooltip>
+        )
+      )}
+      {authorized && (
+        <>
+          <CRUDMenu
+            show={state.showMenu}
+            onEdit={() => setState({ ...state, showMenu: null, edit: true })}
+            onDelete={() => {
+              setState({ ...state, showMenu: null });
+              handleDelete(response?._id, form?._id);
+            }}
+            onClose={() => setState({ ...state, showMenu: null })}
+          />
+          {state.edit && (
+            <>
+              <EditResponseDrawer
+                form={form}
+                response={response}
+                open={state.edit}
+                onClose={() => {
+                  setState({ ...state, edit: false });
+                }}
+              />
+            </>
+          )}
+        </>
       )}
       <Grid container spacing={1}>
-        {!(hideAuthor || hideNavigation || hideBreadcrumbs) && (
+        {hideLeftNavigation && (
           <Grid item xs={3}>
             <div
               className={`d-flex ${
@@ -202,10 +216,10 @@ export function ResponseChild3({
             </div>
           </Grid>
         )}
-        <Grid item xs={hideAuthor ? 12 : 9}>
+        <Grid item xs={!hideLeftNavigation ? 12 : 9}>
           <Paper
             variant="outlined"
-            style={hideAuthor ? { border: 'none' } : {}}
+            style={!hideLeftNavigation ? { border: 'none' } : {}}
             className={`d-flex ${
               section?.options?.belowResponse ? 'flex-column-reverse' : 'flex-column'
             }`}


### PR DESCRIPTION
Now you can edit response in overlay if you are owner of that response.
<img width="1440" alt="Screenshot 2022-03-08 at 6 04 57 AM" src="https://user-images.githubusercontent.com/50275510/157142225-223965b5-178b-448c-8336-9867e95082a0.png">



Form settings

<img width="1440" alt="Screenshot 2022-03-08 at 5 58 48 AM" src="https://user-images.githubusercontent.com/50275510/157142314-654f7133-eeaf-45ae-97a6-9ca9d8ade540.png">



Display responses view - Table Vertical
<img width="1440" alt="Screenshot 2022-03-08 at 5 58 50 AM" src="https://user-images.githubusercontent.com/50275510/157142343-a3cbed23-7cda-4201-a252-7c3322fe3548.png">


who can submit the response
<img width="1440" alt="Screenshot 2022-03-08 at 5 58 55 AM" src="https://user-images.githubusercontent.com/50275510/157142362-ad102d31-0288-47a4-a9d4-eddc681b7fa0.png">

All settings are not getting applied, I still working on this





