### PR TITLE
form settings option - which responses user can see

### DIFF
--- a/packages/shared/graphql/query/response.ts
+++ b/packages/shared/graphql/query/response.ts
@@ -100,6 +100,7 @@ export const GET_RESPONSES = gql`
     $limit: Int
     $search: String
     $formField: ID
+    $onlyMy: Boolean
   ) {
     getResponses(
       formId: $formId
@@ -108,6 +109,7 @@ export const GET_RESPONSES = gql`
       limit: $limit
       search: $search
       formField: $formField
+      onlyMy: $onlyMy
     ) {
       count
       data {

--- a/packages/shared/hooks/response/getResponse.ts
+++ b/packages/shared/hooks/response/getResponse.ts
@@ -13,7 +13,12 @@ export const defaultQueryVariables = {
   formField: null,
 };
 
-export function useGetResponses(formId: string, parentId: string = null, formField = null) {
+export function useGetResponses(
+  formId: string,
+  parentId: string = null,
+  formField = null,
+  onlyMy = false,
+) {
   const [subsribed, setSubsribed] = useState(false);
   const [state, setState] = useState({
     ...defaultQueryVariables,
@@ -22,7 +27,7 @@ export function useGetResponses(formId: string, parentId: string = null, formFie
   });
 
   const { data, error, loading, subscribeToMore, refetch } = useQuery(GET_RESPONSES, {
-    variables: { ...state, formId, parentId },
+    variables: { ...state, formId, parentId, onlyMy },
     fetchPolicy: 'cache-and-network',
   });
 

--- a/packages/web/src/components/form2/FormSetting.tsx
+++ b/packages/web/src/components/form2/FormSetting.tsx
@@ -194,13 +194,13 @@ export default function FormSetting({ formId, settings, onChange, isSection }: I
           <FormControlLabel
             control={
               <Checkbox
-                checked={settings?.showResponses ?? false}
-                onChange={({ target }) => onChange({ showResponses: target.checked })}
+                checked={settings?.onlyMyResponses ?? false}
+                onChange={({ target }) => onChange({ onlyMyResponses: target.checked })}
                 name="showFormResponses"
                 color="primary"
               />
             }
-            label="Users can view all form responses"
+            label="Users can view only their own responses"
           />
         </>
       )}

--- a/packages/web/src/components/form2/FormView.tsx
+++ b/packages/web/src/components/form2/FormView.tsx
@@ -81,7 +81,9 @@ export default function FormViewWrapper({
     parentId,
   );
 
-  const { data, error, refetch } = useGetResponses(form?._id, parentId);
+  const showOnlyMyResponses = !isPageOwner && form?.settings?.onlyMyResponses;
+
+  const { data, error, refetch } = useGetResponses(form?._id, parentId, null, showOnlyMyResponses);
   const [state, setState] = useState(initialState);
   const authenticated = useSelector(({ auth }: any) => auth.authenticated);
   const [showOverlayResult, setShowOverlayResult] = useState(true);
@@ -131,22 +133,20 @@ export default function FormViewWrapper({
     return response;
   };
 
-  let canSubmit = authenticated;
-  if (form?.settings?.whoCanSubmit) {
-    canSubmit =
-      (form?.settings?.multipleResponses || data?.getResponses?.data?.length === 0) &&
-      ((authenticated && isPageOwner && form?.settings?.whoCanSubmit === 'onlyPageOwner') ||
-        (authenticated && form?.settings?.whoCanSubmit === 'authUser') ||
-        form?.settings?.whoCanSubmit === 'all');
-  }
+  const canSubmit =
+    (authenticated && !form?.settings?.whoCanSubmit) ||
+    (authenticated &&
+      isPageOwner &&
+      form?.settings?.whoCanSubmit === 'onlyPageOwner' &&
+      (form?.settings?.multipleResponses || data?.getResponses?.data?.length === 0)) ||
+    (authenticated && form?.settings?.whoCanSubmit === 'authUser') ||
+    form?.settings?.whoCanSubmit === 'all';
 
-  let canViewResponses = authenticated;
-  if (form?.settings?.whoCanViewResponses) {
-    canViewResponses =
-      (authenticated && isPageOwner && form?.settings?.whoCanViewResponses === 'onlyPageOwner') ||
-      (authenticated && form?.settings?.whoCanViewResponses === 'authUser') ||
-      form?.settings?.whoCanViewResponses === 'all';
-  }
+  const canViewResponses =
+    (authenticated && !form?.settings?.whoCanViewResponses) ||
+    (authenticated && isPageOwner && form?.settings?.whoCanViewResponses === 'onlyPageOwner') ||
+    (authenticated && form?.settings?.whoCanViewResponses === 'authUser') ||
+    form?.settings?.whoCanViewResponses === 'all';
 
   return (
     <div>
@@ -278,7 +278,12 @@ export default function FormViewWrapper({
       {canViewResponses &&
         form?.settings?.widgetType !== 'form' &&
         form?.settings?.responsesView !== 'button' && (
-          <ResponseList layouts={layouts} form={form} parentId={parentId} />
+          <ResponseList
+            layouts={layouts}
+            form={form}
+            parentId={parentId}
+            showOnlyMyResponses={showOnlyMyResponses}
+          />
         )}
     </div>
   );

--- a/packages/web/src/components/response/ResponseList.tsx
+++ b/packages/web/src/components/response/ResponseList.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useGetForm } from '@frontend/shared/hooks/form';
 import { useRouter } from 'next/router';
 import moment from 'moment';
 import Paper from '@material-ui/core/Paper';
@@ -16,6 +15,8 @@ import IconButton from '@material-ui/core/IconButton';
 import LaunchIcon from '@material-ui/icons/Launch';
 import EditIcon from '@material-ui/icons/Edit';
 import { useGetResponses, useDeleteResponse } from '@frontend/shared/hooks/response';
+import { ReactHeight } from 'react-height';
+import Button from '@material-ui/core/Button';
 import ErrorLoading from '../common/ErrorLoading';
 import Backdrop from '../common/Backdrop';
 import { onAlert } from '../../utils/alert';
@@ -24,18 +25,27 @@ import Authorization from '../common/Authorization';
 import DeleteButton from '../common/DeleteButton';
 import { ResponseChild3 } from './Response';
 import EditResponseDrawer from './EditResponseDrawer';
-import { ReactHeight } from 'react-height';
-import Button from '@material-ui/core/Button';
 import Overlay from '../common/Overlay';
 
 interface IProps {
   form: any;
   parentId?: string;
   layouts?: any;
+  showOnlyMyResponses?: boolean;
 }
 
-export default function ResponseList({ form, parentId, layouts }: IProps): any {
-  const { data, error, state, setState } = useGetResponses(form._id, parentId);
+export default function ResponseList({
+  form,
+  parentId,
+  layouts,
+  showOnlyMyResponses,
+}: IProps): any {
+  const { data, error, state, setState } = useGetResponses(
+    form._id,
+    parentId,
+    null,
+    showOnlyMyResponses,
+  );
   const [height, setHeight] = useState(0);
   let gridHeight = 0;
   if (layouts) {


### PR DESCRIPTION
By using form setting - Users can view only their own responses
you can control which responses can view (their own or all responses)

<img width="1440" alt="Screenshot 2022-03-10 at 5 33 32 AM" src="https://user-images.githubusercontent.com/50275510/157560402-a7f8af7a-64eb-4ac6-bd26-af0c0c7af600.png">
